### PR TITLE
Change Dockerfile script to use scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ COPY . /go/src/github.com/fahernandez/go-linter-test-error-handling
 WORKDIR /go/src/github.com/fahernandez/go-linter-test-error-handling
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o go-linter-test-error-handling main.go
 
-FROM alpine:3.10
-RUN apk add --no-cache --update ca-certificates curl tzdata && rm -rf /var/cache/apk/*
+FROM scratch
 
 COPY --from=builder /go/src/github.com/fahernandez/go-linter-test-error-handling/go-linter-test-error-handling /go-linter-test-error-handling
 


### PR DESCRIPTION
`scratch` is a base image used in docker when it's not necessary to rely on an operating system in order to interact with the binary. I fully recommend this for Go binaries since they don't rely on Alpine to be executed. Give it a try! :)

More info about `scratch`:
* https://medium.com/@chemidy/create-the-smallest-and-secured-golang-docker-image-based-on-scratch-4752223b7324
* https://bitfieldconsulting.com/golang/docker-image#build-your-golang-docker-container-image